### PR TITLE
RCON Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "Assets/UnityStandardAssets"]
 	path = Assets/UnityStandardAssets
 	url = https://github.com/GTA-ASM/UnityStandardAssets
+[submodule "Assets/RCONdotnet"]
+	path = Assets/RCONdotnet
+	url = https://github.com/undbsd/rcon-dotnet

--- a/Assets/Prefabs/GameManager.prefab
+++ b/Assets/Prefabs/GameManager.prefab
@@ -24,6 +24,7 @@ GameObject:
   - component: {fileID: 1318502437576191535}
   - component: {fileID: 7442340376164908290}
   - component: {fileID: 8446601354455743255}
+  - component: {fileID: 5853763562556677784}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -299,3 +300,15 @@ MonoBehaviour:
     type: 3}
   messagesContainer: {fileID: 0}
   messagePoolSize: 10
+--- !u!114 &5853763562556677784
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1297494511425690}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c77317cdc437f244b8d409c229aa2e95, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/RCONdotnet.meta
+++ b/Assets/RCONdotnet.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: be08b0c2aac61f94f8676008c1f1a546
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/config.json
+++ b/Assets/Resources/config.json
@@ -41,6 +41,7 @@
 
   "dontLoadTextures": false,
 
-  "RCONpassword": "super_secret_password",
-  "RCONport": 25575
+  "RCON_enabled": false,
+  "RCON_password": "super_secret_password",
+  "RCON_port": 25575
 }

--- a/Assets/Resources/config.json
+++ b/Assets/Resources/config.json
@@ -10,7 +10,7 @@
   "sv_max_connections": 32,
   "sv_port": 14242,
 
-  "game_dir" : "",
+  "game_dir": "",
 
   "archive_paths": [
     "${game_dir}/models/gta3.img",
@@ -35,10 +35,12 @@
   "water_path": "${game_dir}/data/water.dat",
   "car_colors_path": "${game_dir}/data/carcols.dat",
   "anim_groups_paths": [
-    "${game_dir}/data/animgrp.dat",
+    "${game_dir}/data/animgrp.dat"
   ],
   "weapons_path": "${game_dir}/data/weapon.dat",
 
   "dontLoadTextures": false,
-  
+
+  "RCONpassword": "super_secret_password",
+  "RCONport": 25575
 }

--- a/Assets/Scripts/Networking/CustomNetworkManager.cs
+++ b/Assets/Scripts/Networking/CustomNetworkManager.cs
@@ -48,7 +48,8 @@ namespace SanAndreasUnity.Net
         {
             if (NetStatus.IsServer)
             {
-                RCON.RCONManager.StartServer();
+                if (Config.Get<bool>("RCON_enabled"))
+                    RCON.RCONManager.StartServer();
                 return; // don't do anything on server
             }
 

--- a/Assets/Scripts/Networking/CustomNetworkManager.cs
+++ b/Assets/Scripts/Networking/CustomNetworkManager.cs
@@ -46,8 +46,11 @@ namespace SanAndreasUnity.Net
 
         void OnLoaderFinished()
         {
-            if (NetStatus.IsServer) // don't do anything on server
-                return;
+            if (NetStatus.IsServer)
+            {
+                RCON.RCONManager.StartServer();
+                return; // don't do anything on server
+            }
 
             if (!NetworkClient.isConnected)
             {

--- a/Assets/Scripts/Networking/CustomNetworkManager.cs
+++ b/Assets/Scripts/Networking/CustomNetworkManager.cs
@@ -46,12 +46,8 @@ namespace SanAndreasUnity.Net
 
         void OnLoaderFinished()
         {
-            if (NetStatus.IsServer)
-            {
-                if (Config.Get<bool>("RCON_enabled"))
-                    RCON.RCONManager.StartServer();
-                return; // don't do anything on server
-            }
+            if (NetStatus.IsServer) // don't do anything on server
+                return;
 
             if (!NetworkClient.isConnected)
             {

--- a/Assets/Scripts/RCON.meta
+++ b/Assets/Scripts/RCON.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 381eb0e589457424db93a1587f86f9eb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/RCON/CommandInterpreter.cs
+++ b/Assets/Scripts/RCON/CommandInterpreter.cs
@@ -3,30 +3,34 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class CommandInterpreter
+namespace SanAndreasUnity.RCON
 {
-    public static String Interpret(String command)
+    public class CommandInterpreter
     {
-        string[] words = command.Split(' ');
-
-        if (command == "heartbeat")
+        public static String Interpret(String command)
         {
-            // Implement heartbeat ping
-            return "Heartbeat was sent to master server";
-        }
+            string[] words = command.Split(' ');
 
-        if (command == "help")
-        {
-            return "The available commands for now are heartbeat, announce and help";
-        }
+            if (command == "heartbeat")
+            {
+                // Implement heartbeat ping
+                return "Heartbeat was sent to master server";
+            }
 
-        if (words[0] == "announce")
-        {
-            String announcement = String.Join(" ", words, 1, words.Length - 1);
-            SanAndreasUnity.Chat.ChatManager.SendChatMessageToAllPlayersAsServer(announcement);
-            return "Server : " + announcement;
-        }
+            if (command == "help")
+            {
+                return "The available commands for now are heartbeat, announce and help";
+            }
 
-        return "Unknown command";
+            if (words[0] == "announce")
+            {
+                String announcement = String.Join(" ", words, 1, words.Length - 1);
+                SanAndreasUnity.Chat.ChatManager.SendChatMessageToAllPlayersAsServer(announcement);
+                return "Server : " + announcement;
+            }
+
+            return "Unknown command";
+        }
     }
+
 }

--- a/Assets/Scripts/RCON/CommandInterpreter.cs
+++ b/Assets/Scripts/RCON/CommandInterpreter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CommandInterpreter
+{
+    public static String Interpret(String command)
+    {
+        string[] words = command.Split(' ');
+
+        if (command == "heartbeat")
+        {
+            // Implement heartbeat ping
+            return "Heartbeat was sent to master server";
+        }
+
+        if (command == "help")
+        {
+            return "The available commands for now are heartbeat, announce and help";
+        }
+
+        if (words[0] == "announce")
+        {
+            String announcement = String.Join(" ", words, 1, words.Length - 1);
+            SanAndreasUnity.Chat.ChatManager.SendChatMessageToAllPlayersAsServer(announcement);
+            return "Server : " + announcement;
+        }
+
+        return "Unknown command";
+    }
+}

--- a/Assets/Scripts/RCON/CommandInterpreter.cs.meta
+++ b/Assets/Scripts/RCON/CommandInterpreter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9cf8ca8374941dd4aaa862202a1a2b7b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/RCON/RCONManager.cs
+++ b/Assets/Scripts/RCON/RCONManager.cs
@@ -23,8 +23,8 @@ namespace SanAndreasUnity.RCON
 
         public static void StartServer()
         {
-            password = Config.Get<string>("RCONpassword");
-            portNumber = Config.Get<int>("RCONport");
+            password = Config.Get<string>("RCON_password");
+            portNumber = Config.Get<int>("RCON_port");
 
             if (workerInstance != null)
                 return;

--- a/Assets/Scripts/RCON/RCONManager.cs
+++ b/Assets/Scripts/RCON/RCONManager.cs
@@ -71,11 +71,7 @@ namespace SanAndreasUnity.RCON
 
             String commandResult = "Command didn't process correctly"; // default value
 
-            try
-            {
-                commandResult = mainToSec.Take();
-            }
-            catch (InvalidOperationException) { }
+            commandResult = mainToSec.Take();
 
             return commandResult;
         }
@@ -85,11 +81,8 @@ namespace SanAndreasUnity.RCON
         private static void worker_progressChanged(object sender, ProgressChangedEventArgs e)
         {
             String command = "unknown";
-            try
-            {
-                command = secToMain.Take();
-            }
-            catch (InvalidOperationException) { }
+
+            command = secToMain.Take();
 
             mainToSec.Add(CommandInterpreter.Interpret(command));
         }

--- a/Assets/Scripts/RCON/RCONManager.cs
+++ b/Assets/Scripts/RCON/RCONManager.cs
@@ -73,7 +73,6 @@ namespace SanAndreasUnity.RCON
 
             try
             {
-                // TODO add a timeout case ?
                 commandResult = mainToSec.Take();
             }
             catch (InvalidOperationException) { }
@@ -88,7 +87,6 @@ namespace SanAndreasUnity.RCON
             String command = "unknown";
             try
             {
-                // TODO add a timeout case ?
                 command = secToMain.Take();
             }
             catch (InvalidOperationException) { }

--- a/Assets/Scripts/RCON/RCONManager.cs
+++ b/Assets/Scripts/RCON/RCONManager.cs
@@ -1,5 +1,6 @@
 ﻿using Rcon;
 using Rcon.Events;
+using SanAndreasUnity.Utilities;
 using System;
 using System.Collections.Concurrent;
 using System.ComponentModel;
@@ -11,8 +12,8 @@ namespace SanAndreasUnity.RCON
     public class RCONManager : MonoBehaviour
     {
         // Todo : set these from config
-        private static String password = "super_secret_password";
-        private static int portNumber = 25575;
+        private static String password;
+        private static int portNumber;
 
         // Objects used to pass commands and responses between threads
         private static BlockingCollection<String> mainToSec = new BlockingCollection<String>(1);
@@ -22,6 +23,9 @@ namespace SanAndreasUnity.RCON
 
         public static void StartServer()
         {
+            password = Config.Get<string>("RCONpassword");
+            portNumber = Config.Get<int>("RCONport");
+
             if (workerInstance != null)
                 return;
 

--- a/Assets/Scripts/RCON/RCONManager.cs
+++ b/Assets/Scripts/RCON/RCONManager.cs
@@ -1,5 +1,6 @@
 ﻿using Rcon;
 using Rcon.Events;
+using SanAndreasUnity.Net;
 using SanAndreasUnity.Utilities;
 using System;
 using System.Collections.Concurrent;
@@ -85,6 +86,15 @@ namespace SanAndreasUnity.RCON
             command = secToMain.Take();
 
             mainToSec.Add(CommandInterpreter.Interpret(command));
+        }
+
+        void OnLoaderFinished()
+        {
+            if (NetStatus.IsServer)
+            {
+                if (Config.Get<bool>("RCON_enabled"))
+                    StartServer();
+            }
         }
     }
 }

--- a/Assets/Scripts/RCON/RCONManager.cs
+++ b/Assets/Scripts/RCON/RCONManager.cs
@@ -14,20 +14,9 @@ namespace SanAndreasUnity.RCON
         private static String password = "super_secret_password";
         private static int portNumber = 25575;
 
+        // Objects used to pass commands and responses between threads
         private static BlockingCollection<String> mainToSec = new BlockingCollection<String>(1);
         private static BlockingCollection<String> secToMain = new BlockingCollection<String>(1);
-
-        // Object used to pass the requested command string and an awaited callback (promise)
-        class RCONCommandPromise
-        {
-            public RCONCommandPromise(ClientSentCommandEventArgs _command, TaskCompletionSource<String> _promise)
-            {
-                command = _command;
-                promise = _promise;
-            }
-            public ClientSentCommandEventArgs command;
-            public TaskCompletionSource<String> promise;
-        }
 
         private static BackgroundWorker workerInstance = null;
 
@@ -80,7 +69,7 @@ namespace SanAndreasUnity.RCON
 
             try
             {
-                // TODO add a timeout case
+                // TODO add a timeout case ?
                 commandResult = mainToSec.Take();
             }
             catch (InvalidOperationException) { }
@@ -92,8 +81,6 @@ namespace SanAndreasUnity.RCON
         // Runs in main thread
         private static void worker_progressChanged(object sender, ProgressChangedEventArgs e)
         {
-            // Console.WriteLine("Main thread command interpreted {0}", c.Command);
-
             String command = "unknown";
             try
             {

--- a/Assets/Scripts/RCON/RCONManager.cs
+++ b/Assets/Scripts/RCON/RCONManager.cs
@@ -1,0 +1,66 @@
+﻿using Rcon;
+using Rcon.Events;
+using System;
+using System.ComponentModel;
+using UnityEngine;
+
+namespace SanAndreasUnity.RCON
+{
+    public class RCONManager : MonoBehaviour
+    {
+        private static BackgroundWorker workerInstance = null;
+
+        public static void StartServer()
+        {
+            if (workerInstance != null)
+                return;
+
+            workerInstance = new BackgroundWorker();
+
+            workerInstance.DoWork += new DoWorkEventHandler( worker_doWork );
+            workerInstance.ProgressChanged += new ProgressChangedEventHandler( worker_progressChanged );
+            workerInstance.WorkerReportsProgress = true;
+            // workerInstance.WorkerSupportsCancellation = true;
+
+            workerInstance.RunWorkerAsync(); // Call the background worker
+        }
+
+        #region Code that runs in the RCON Server Thread
+        private static void worker_doWork(object sender, DoWorkEventArgs e)
+        {
+            using (RconServer server = new RconServer("super_secret_password", 25575))
+            {
+                server.OnClientCommandReceived += Server_OnClientCommandReceived;
+                server.OnClientConnected += Server_OnClientConnected;
+                server.OnClientAuthenticated += Server_OnClientAuthenticated;
+                server.OnClientDisconnected += Server_OnClientDisconnected;
+                server.Start();
+            }
+        }
+        static void Server_OnClientAuthenticated(object sender, ClientAuthenticatedEventArgs e)
+        {
+            Console.WriteLine("{0} authenticated", e.Client.Client.LocalEndPoint);
+        }
+        static void Server_OnClientDisconnected(object sender, ClientDisconnectedEventArgs e)
+        {
+            Console.WriteLine("{0} disconnected", e.EndPoint);
+        }
+        static void Server_OnClientConnected(object sender, ClientConnectedEventArgs e)
+        {
+            Console.WriteLine("{0} connected", e.Client.Client.LocalEndPoint);
+        }
+        static string Server_OnClientCommandReceived(object sender, ClientSentCommandEventArgs e)
+        {
+            workerInstance.ReportProgress(0, e); //Report our progress to the main thread
+            return "response string goes here";
+        }
+        #endregion
+
+        // Runs in main thread
+        private static void worker_progressChanged(object sender, ProgressChangedEventArgs e)
+        {
+            ClientSentCommandEventArgs c = (ClientSentCommandEventArgs)e.UserState;
+            Console.WriteLine("Main thread command interpreted {0}", c.Command);
+        }
+    }
+}

--- a/Assets/Scripts/RCON/RCONManager.cs
+++ b/Assets/Scripts/RCON/RCONManager.cs
@@ -2,12 +2,29 @@
 using Rcon.Events;
 using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace SanAndreasUnity.RCON
 {
     public class RCONManager : MonoBehaviour
     {
+        // Todo : set these from config
+        private static String password = "super_secret_password";
+        private static int portNumber = 25575;
+
+        // Object used to pass the requested command string and an awaited callback (promise)
+        class RCONCommandPromise
+        {
+            public RCONCommandPromise(ClientSentCommandEventArgs _command, TaskCompletionSource<String> _promise)
+            {
+                command = _command;
+                promise = _promise;
+            }
+            public ClientSentCommandEventArgs command;
+            public TaskCompletionSource<String> promise;
+        }
+
         private static BackgroundWorker workerInstance = null;
 
         public static void StartServer()
@@ -28,7 +45,7 @@ namespace SanAndreasUnity.RCON
         #region Code that runs in the RCON Server Thread
         private static void worker_doWork(object sender, DoWorkEventArgs e)
         {
-            using (RconServer server = new RconServer("super_secret_password", 25575))
+            using (RconServer server = new RconServer(password, portNumber))
             {
                 server.OnClientCommandReceived += Server_OnClientCommandReceived;
                 server.OnClientConnected += Server_OnClientConnected;
@@ -39,28 +56,42 @@ namespace SanAndreasUnity.RCON
         }
         static void Server_OnClientAuthenticated(object sender, ClientAuthenticatedEventArgs e)
         {
-            Console.WriteLine("{0} authenticated", e.Client.Client.LocalEndPoint);
+            // Console.WriteLine("{0} authenticated", e.Client.Client.LocalEndPoint);
         }
         static void Server_OnClientDisconnected(object sender, ClientDisconnectedEventArgs e)
         {
-            Console.WriteLine("{0} disconnected", e.EndPoint);
+            // Console.WriteLine("{0} disconnected", e.EndPoint);
         }
         static void Server_OnClientConnected(object sender, ClientConnectedEventArgs e)
         {
-            Console.WriteLine("{0} connected", e.Client.Client.LocalEndPoint);
+            // Console.WriteLine("{0} connected", e.Client.Client.LocalEndPoint);
         }
         static string Server_OnClientCommandReceived(object sender, ClientSentCommandEventArgs e)
         {
-            workerInstance.ReportProgress(0, e); //Report our progress to the main thread
-            return "response string goes here";
+            TaskCompletionSource<String> promise = new TaskCompletionSource<String>();
+            RCONCommandPromise pass = new RCONCommandPromise(e, promise);
+
+            workerInstance.ReportProgress(0, pass); //Report our progress to the main thread
+
+            String commandResult = "Command didn't process correctly"; // default value
+
+            // TODO add a timeout case
+            commandResult = promise.Task.GetAwaiter().GetResult();
+
+            return commandResult;
         }
         #endregion
 
         // Runs in main thread
         private static void worker_progressChanged(object sender, ProgressChangedEventArgs e)
         {
-            ClientSentCommandEventArgs c = (ClientSentCommandEventArgs)e.UserState;
-            Console.WriteLine("Main thread command interpreted {0}", c.Command);
+            RCONCommandPromise rcp = (RCONCommandPromise)e.UserState;
+            ClientSentCommandEventArgs c = rcp.command;
+            TaskCompletionSource<String> promise = rcp.promise;
+
+            // Console.WriteLine("Main thread command interpreted {0}", c.Command);
+
+            promise.TrySetResult(CommandInterpreter.Interpret(c.Command));
         }
     }
 }

--- a/Assets/Scripts/RCON/RCONManager.cs
+++ b/Assets/Scripts/RCON/RCONManager.cs
@@ -65,9 +65,9 @@ namespace SanAndreasUnity.RCON
         }
         static string Server_OnClientCommandReceived(object sender, ClientSentCommandEventArgs e)
         {
-            workerInstance.ReportProgress(0); //Report our progress to the main thread
-
             secToMain.Add(e.Command); // Pass the command to the main thread
+
+            workerInstance.ReportProgress(0); //Report our progress to the main thread
 
             String commandResult = "Command didn't process correctly"; // default value
 

--- a/Assets/Scripts/RCON/RCONManager.cs.meta
+++ b/Assets/Scripts/RCON/RCONManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c77317cdc437f244b8d409c229aa2e95
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# RCON Support

Default config values:
```
{
  "RCON_enabled": false,
  "RCON_password": "super_secret_password",
  "RCON_port": 25575
}
```

To enable RCON, you have to set `RCON_enabled` to `true`.

The commands are processed in `Assets/Scripts/RCON/CommandInterpreter.cs`